### PR TITLE
feature(22): Adding release parameter

### DIFF
--- a/overturemaps/core.py
+++ b/overturemaps/core.py
@@ -15,8 +15,9 @@ except ImportError:
     GeoDataFrame = None
 
 BoundingBox: TypeAlias = Tuple[float, float, float, float]
+default_release = "2024-12-18.0"
 
-def record_batch_reader(overture_type: str, bbox: BoundingBox | None = None, release: str = "2024-12-18.0") -> Optional[pa.RecordBatchReader]:
+def record_batch_reader(overture_type: str, bbox: BoundingBox | None = None, release: str = default_release) -> Optional[pa.RecordBatchReader]:
     """
     Return a pyarrow RecordBatchReader for the desired bounding box and s3 path
     """
@@ -50,7 +51,7 @@ def record_batch_reader(overture_type: str, bbox: BoundingBox | None = None, rel
     reader = pa.RecordBatchReader.from_batches(geoarrow_schema, non_empty_batches)
     return reader
 
-def geodataframe(overture_type: str, bbox: BoundingBox | None = None, release: str = "2024-12-18.0") -> GeoDataFrame:
+def geodataframe(overture_type: str, bbox: BoundingBox | None = None, release: str = default_release) -> GeoDataFrame:
     """
     Loads geoparquet for specified type into a geopandas dataframe
 
@@ -118,7 +119,7 @@ type_theme_map = {
 }
 
 
-def _dataset_path(overture_type: str, release: str="2024-12-18.0") -> str:
+def _dataset_path(overture_type: str, release: str=default_release) -> str:
     """
     Returns the s3 path of the Overture dataset to use. This assumes overture_type has
     been validated, e.g. by the CLI


### PR DESCRIPTION
* My ETL Workflows handle multiple Overture releases. I need a way to specify which release I'm downloading otherwise write new code
* This PR adds a parameter `release` that takes a string like `2024-12-18.0` which corresponds to an Overture release in S3
* Adds default values so it defaults to latest hardcoded `2024-12-18.0` ensuring backwards compatibility. No CLI code needs to be modified
* When the default value needs to be updated, change the variable `default_release`
* Adds some enhanced `Typing` suggestions